### PR TITLE
Update to draft-illyes-webbotauth-jafar-00

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![License](https://img.shields.io/github/license/thibmeu/jafar)
 
-This repository contains the [JSON Schema](https://json-schema.org/) implementation for JAFAR (JSON-Based Format for Publishing IP Ranges of Automated HTTP Clients), as defined in [draft-illyes-aipref-jafar-02](https://datatracker.ietf.org/doc/html/draft-illyes-aipref-jafar-02).
+This repository contains the [JSON Schema](https://json-schema.org/) implementation for JAFAR (JSON-Based Format for Publishing IP Ranges of Automated HTTP Clients), as defined in [draft-illyes-webbotauth-jafar-00](https://datatracker.ietf.org/doc/html/draft-illyes-webbotauth-jafar-00).
 
 JAFAR provides a machine-readable format for automated HTTP client operators (web crawlers, AI bots, etc.) to publish their IP address ranges, enabling website operators to identify and verify legitimate automated traffic.
 
@@ -18,7 +18,7 @@ JAFAR provides a machine-readable format for automated HTTP client operators (we
 
 - JAFAR validation, including IPv4 and IPv6 prefixes
 - JSON Schema 2020-12 compliant
-- Schema URL `https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json`
+- Schema URL `https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-webbotauth-jafar-00/schema.json`
 
 ## Real-World Examples
 
@@ -36,7 +36,7 @@ The JSON Schema is provided in [schema.json](./schema.json).
 
 ### Media Type
 
-JAFAR documents use the media type `application/jafar+json`.
+JAFAR documents use the media type `application/jafar+json`. There is an optional `version` parameter.
 
 ### Editor Integration
 
@@ -44,7 +44,7 @@ Add `$schema` to your JAFAR documents for IDE autocompletion and inline validati
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
+  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-webbotauth-jafar-00/schema.json",
   "creationTime": "2025-08-15T14:30:00Z",
   "prefixes": [...]
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![License](https://img.shields.io/github/license/thibmeu/jafar)
 
-This repository contains the [JSON Schema](https://json-schema.org/) implementation for JAFAR (JSON-Based Format for Publishing IP Ranges of Automated HTTP Clients), as defined in [draft-illyes-aipref-jafar-00](https://datatracker.ietf.org/doc/html/draft-illyes-aipref-jafar-00).
+This repository contains the [JSON Schema](https://json-schema.org/) implementation for JAFAR (JSON-Based Format for Publishing IP Ranges of Automated HTTP Clients), as defined in [draft-illyes-aipref-jafar-02](https://datatracker.ietf.org/doc/html/draft-illyes-aipref-jafar-02).
 
 JAFAR provides a machine-readable format for automated HTTP client operators (web crawlers, AI bots, etc.) to publish their IP address ranges, enabling website operators to identify and verify legitimate automated traffic.
 
@@ -18,7 +18,7 @@ JAFAR provides a machine-readable format for automated HTTP client operators (we
 
 - JAFAR validation, including IPv4 and IPv6 prefixes
 - JSON Schema 2020-12 compliant
-- Schema URL `https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-00/schema.json`
+- Schema URL `https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json`
 
 ## Real-World Examples
 
@@ -34,15 +34,17 @@ The following services publish IP ranges in JAFAR-adjacent formats:
 
 The JSON Schema is provided in [schema.json](./schema.json).
 
+### Media Type
+
+JAFAR documents use the media type `application/jafar+json`.
+
 ### Editor Integration
 
 Add `$schema` to your JAFAR documents for IDE autocompletion and inline validation:
 
 ```json
 {
-  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-00/schema.json",
-  "formatVersion": "1.0",
-  "synctoken": "...",
+  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
   "creationTime": "2025-08-15T14:30:00Z",
   "prefixes": [...]
 }

--- a/examples/1-basic-publication.json
+++ b/examples/1-basic-publication.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
+  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-webbotauth-jafar-00/schema.json",
   "synctoken": "example 1",
   "creationTime": "2025-08-15T14:30:00Z",
   "prefixes": [

--- a/examples/2-publication-with-multiple-services.json
+++ b/examples/2-publication-with-multiple-services.json
@@ -1,29 +1,28 @@
 {
-  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-00/schema.json",
-  "formatVersion": "1.0",
+  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
   "synctoken": "example 2",
   "creationTime": "2025-09-01T10:00:00Z",
   "notes": "IP ranges for ExampleCloud services. For verification, FCrDNS is also recommended.",
   "prefixes": [
     {
       "ipv4Prefix": "192.0.2.0/24",
-      "service": "TEST-NET-1"
+      "services": ["TEST-NET-1"]
     },
     {
       "ipv4Prefix": "198.51.100.0/24",
-      "service": "TEST-NET-2"
+      "services": ["TEST-NET-2"]
     },
     {
       "ipv4Prefix": "203.0.113.0/24",
-      "service": "TEST-NET-3"
+      "services": ["TEST-NET-3"]
     },
     {
       "ipv6Prefix": "2001:db8::/32",
-      "service": "RFC 3849"
+      "services": ["RFC 3849"]
     },
     {
       "ipv6Prefix": "3fff::/20",
-      "service": "RFC 9637"
+      "services": ["RFC 9637"]
     }
   ]
 }

--- a/examples/2-publication-with-multiple-services.json
+++ b/examples/2-publication-with-multiple-services.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
+  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-webbotauth-jafar-00/schema.json",
   "synctoken": "example 2",
   "creationTime": "2025-09-01T10:00:00Z",
   "notes": "IP ranges for ExampleCloud services. For verification, FCrDNS is also recommended.",

--- a/examples/3-draft-advanced-publication.json
+++ b/examples/3-draft-advanced-publication.json
@@ -1,16 +1,14 @@
 {
   "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
-  "synctoken": "example 1",
   "creationTime": "2025-08-15T14:30:00Z",
   "prefixes": [
     {
-      "ipv4Prefix": "66.249.64.0/20"
+      "ipv4Prefix": "66.249.64.0/24",
+      "services": ["ExampleCloud-Crawler", "ExampleCloud-Ads"]
     },
     {
-      "ipv4Prefix": "34.64.0.0/12"
-    },
-    {
-      "ipv6Prefix": "2001:4860:4000::/36"
+      "ipv6Prefix": "2001:4860:4860::/48",
+      "services": ["ExampleCloud-Fetcher"]
     }
   ]
 }

--- a/examples/3-draft-advanced-publication.json
+++ b/examples/3-draft-advanced-publication.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
+  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-webbotauth-jafar-00/schema.json",
   "creationTime": "2025-08-15T14:30:00Z",
   "prefixes": [
     {

--- a/examples/4-draft-aggregated-publication.json
+++ b/examples/4-draft-aggregated-publication.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
+  "synctoken": "20260410223000",
+  "creationTime": "2026-04-10T22:30:00Z",
+  "notes": "Aggregated feed of verified automated clients. Attribution maintained via services array. Data refreshed every 24 hours.",
+  "prefixes": [
+    {
+      "ipv4Prefix": "192.0.2.0/24",
+      "services": ["SearchEngine-A-Crawler", "SearchEngine-A-ImageBot"]
+    },
+    {
+      "ipv4Prefix": "198.51.100.0/24",
+      "services": ["SocialMedia-B-Preview"]
+    },
+    {
+      "ipv6Prefix": "2001:db8:abc::/48",
+      "services": ["TechCo-C-HealthCheck", "TechCo-C-Ads"]
+    }
+  ]
+}

--- a/examples/4-draft-aggregated-publication.json
+++ b/examples/4-draft-aggregated-publication.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
+  "$schema": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-webbotauth-jafar-00/schema.json",
   "synctoken": "20260410223000",
   "creationTime": "2026-04-10T22:30:00Z",
   "notes": "Aggregated feed of verified automated clients. Attribution maintained via services array. Data refreshed every 24 hours.",

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
-  "$comment": "JSON Schema for JAFAR (JSON-Based Format for Publishing IP Ranges of Automated HTTP Clients). See https://datatracker.ietf.org/doc/html/draft-illyes-aipref-jafar-02",
+  "$id": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-webbotauth-jafar-00/schema.json",
+  "$comment": "JSON Schema for JAFAR (JSON-Based Format for Publishing IP Ranges of Automated HTTP Clients). See https://datatracker.ietf.org/doc/html/draft-illyes-webbotauth-jafar-00",
   "title": "JAFAR",
   "description": "A machine-readable format for automated HTTP client operators to publish their IP address ranges.",
   "type": "object",

--- a/schema.json
+++ b/schema.json
@@ -1,17 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-00/schema.json",
-  "$comment": "JSON Schema for JAFAR (JSON-Based Format for Publishing IP Ranges of Automated HTTP Clients). See https://datatracker.ietf.org/doc/html/draft-illyes-aipref-jafar-00",
+  "$id": "https://raw.githubusercontent.com/thibmeu/jafar/refs/heads/draft-illyes-aipref-jafar-02/schema.json",
+  "$comment": "JSON Schema for JAFAR (JSON-Based Format for Publishing IP Ranges of Automated HTTP Clients). See https://datatracker.ietf.org/doc/html/draft-illyes-aipref-jafar-02",
   "title": "JAFAR",
   "description": "A machine-readable format for automated HTTP client operators to publish their IP address ranges.",
   "type": "object",
   "properties": {
-    "formatVersion": {
-      "type": "string",
-      "pattern": "^\\d+\\.\\d+$",
-      "description": "The version of the JAFAR format used in this document.",
-      "examples": ["1.0"]
-    },
     "synctoken": {
       "type": "string",
       "description": "An opaque token that changes when the document content changes, used for caching and synchronization.",
@@ -49,10 +43,11 @@
             "description": "An IPv6 CIDR prefix (e.g., \"2001:db8::/32\").",
             "examples": ["2001:db8::/32", "2001:4860:4000::/36"]
           },
-          "service": {
-            "type": "string",
-            "description": "An optional identifier for the service or product using this prefix.",
-            "examples": ["Bingbot", "AdsBot-Google"]
+          "services": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "An optional list of service or product identifiers using this prefix.",
+            "examples": [["Bingbot", "AdsBot-Google"]]
           }
         },
         "oneOf": [
@@ -66,5 +61,5 @@
       }
     }
   },
-  "required": ["formatVersion", "synctoken", "creationTime", "prefixes"]
+  "required": ["creationTime", "prefixes"]
 }


### PR DESCRIPTION
-02 has not yet been cut, but will include some changes (check the [diff](https://author-tools.ietf.org/api/iddiff?doc_1=draft-illyes-aipref-jafar&url_2=https://garyillyes.github.io/jafar/draft-illyes-aipref-jafar.txt))

1. removal of formatVersion
2. introduction of a media type. this is obviously not included in the schema, but should be in the readme
3. support for services instead of service
4. New examples

Closes #4